### PR TITLE
16 bit access on an odd address

### DIFF
--- a/project/boot/boot.s
+++ b/project/boot/boot.s
@@ -354,7 +354,7 @@ main_frt:
         bt      9f
         /* overflow */
         mov     #0,r0
-        mov.w   r0,@r1  /* clear OVF IRQ */
+        mov.b   r0,@r1  /* clear OVF IRQ */
 
         mov.l   frt_ovf_count_ptr,r1
         mov.l   @r1,r0


### PR DESCRIPTION
16 bit access on an odd address is not allowed, use move.b instead